### PR TITLE
Auto include file name

### DIFF
--- a/CopyrightCommand.py
+++ b/CopyrightCommand.py
@@ -20,16 +20,17 @@ class CopyrightCommand(sublime_plugin.TextCommand):
         self.view = view
         self.selected_owner = None
 
-    def format_pattern(self, year, owner):
+    def format_pattern(self, year, owner, fileName):
         """Creates a search pattern for the copyright text."""
-        text = self.format_text("yyyear", "ooowner")
+        text = self.format_text("yyyear", "ooowner", "fffileName")
         text = re.escape(text)
         text = text.replace("yyyear", year)
+        text = text.replace("fffileName", fileName)
         pattern = text.replace("ooowner", owner)
 
         return pattern
 
-    def format_text(self, year, owner):
+    def format_text(self, year, owner, fileName):
         """Formats the text of the copyright message."""
         if year is None:
             raise TypeError("year cannot be None.")
@@ -40,6 +41,7 @@ class CopyrightCommand(sublime_plugin.TextCommand):
         text = self.settings.get(AutoCopyright.constants.SETTING_COPYRIGHT_MESSAGE)
         text = text.replace("%y", str(year))
         text = text.replace("%o", owner)
+        text = text.replace("%f", fileName)
 
         return text
 

--- a/InsertCopyrightCommand.py
+++ b/InsertCopyrightCommand.py
@@ -55,7 +55,8 @@ class InsertCopyrightCommand(CopyrightCommand):
         """Finishes inserting the copyright text after the owner is selected."""
         year = datetime.date.today().year
         location = self.determine_location()
-        text = self.format_text(year, self.selected_owner)
+        fileName = self.get_fileName()
+        text = self.format_text(year, self.selected_owner, fileName)
         copyrightText = self.__build_comment(text)
 
         self.view.insert(self.edit, location, copyrightText)
@@ -169,6 +170,15 @@ class InsertCopyrightCommand(CopyrightCommand):
             copyright += self.lastLine.strip() + endings
 
         return copyright
+
+    def get_fileName(self):
+        """Get the actual file name."""
+        fileName = sublime.active_window().active_view().file_name()
+        if fileName is not None:
+            fileName = os.path.basename(fileName)
+            return fileName
+        else:
+            return "unknown-filename"
 
     def __get_owner(self):
         """Gets the copyright owner name that should be used in the copyright message."""

--- a/UpdateCopyrightCommand.py
+++ b/UpdateCopyrightCommand.py
@@ -5,6 +5,8 @@
 import AutoCopyright.constants
 import datetime
 import re
+import sublime
+import os
 
 from AutoCopyright.CopyrightCommand import CopyrightCommand
 from AutoCopyright.Exception import MissingOwnerException
@@ -59,14 +61,23 @@ class UpdateCopyrightCommand(CopyrightCommand):
 
         return owners
 
+    def get_fileName(self):
+        """Get the actual file name."""
+        fileName = sublime.active_window().active_view().file_name()
+        if fileName is not None:
+            fileName = os.path.basename(fileName)
+            return fileName
+        else:
+            return "unknown-filename"
+
     def get_patterns(self):
         """Gets the patterns to use to find the copyright text."""
         owners = self.get_owners()
-
+        fileName = self.get_fileName()
         if self.patterns is None:
             self.patterns = {}
             for owner in owners:
-                self.patterns[self.format_pattern("(\d+)(-\d+)?", owner)] = owner
+                self.patterns[self.format_pattern("(\d+)(-\d+)?", owner, fileName)] = owner
 
         return self.patterns
 
@@ -94,7 +105,8 @@ class UpdateCopyrightCommand(CopyrightCommand):
     def __replace_match(self, region, oldYear, newYear):
         """Replace the old copyright text with the new copyright text."""
         owner = self.patterns[self.matched_pattern]
-        message = self.format_text(oldYear + "-" + newYear, owner)
+        fileName = self.get_fileName();
+        message = self.format_text(oldYear + "-" + newYear, owner, fileName)
         self.view.replace(self.edit, region, message)
         self.edit = None
 


### PR DESCRIPTION
Here's my pull request I told later.

Add %f in preferences and it will include the file name when inserting the copyright.

One project I'm working include the file name and this makes things easier to me. It won't update if the file name is changed without SublimeText. If you 'save as' with SublimeText it updates.

I haven't tested this on SublimeText 3, only with SublimeText 2, I kind of merged the changes for the master branch.
